### PR TITLE
Fix deprecated method warning

### DIFF
--- a/pyramid_sacrud/includes/database.py
+++ b/pyramid_sacrud/includes/database.py
@@ -21,4 +21,4 @@ def includeme(config):
     DBSession = crud_sessionmaker(scoped_session(
         sessionmaker(extension=ZopeTransactionExtension())))
     DBSession.configure(bind=engine)
-    config.set_request_property(lambda x: DBSession, 'dbsession', reify=True)
+    config.add_request_method(lambda x: DBSession, 'dbsession', reify=True, property=True)


### PR DESCRIPTION
set_request_property is deprecated from Pyramid 1.4 and issues a deprecation warning as of 1.5+ saying to use add_request_method instead. This commit just adjusts it to use the non-deprecated method.